### PR TITLE
fix typo, change file extension txt to tex

### DIFF
--- a/src/chap/chap.01.basics.tex
+++ b/src/chap/chap.01.basics.tex
@@ -86,7 +86,7 @@
 \caption{\LaTeX\ 的一个最简单的源代码示例。}\label{code:hello-world}
 \end{sourcecode}
 
-假设将源代码 \ref{code:hello-world} 保存成 \texttt{helloworld.txt}。如果使用 \TeX works 或 \TeX studio 等编辑器，
+假设将源代码 \ref{code:hello-world} 保存成 \texttt{helloworld.tex}。如果使用 \TeX works 或 \TeX studio 等编辑器，
 点击编辑器提供的“编译”按钮即可。在此建议将编译命令设为 “XeLaTeX”。编译成功后生成文档 \texttt{helloworld.pdf}。
 
 另外也可以使用命令行的方式调用程序进行编译（笔者建议尝试命令行方式，以了解背后的工作原理）。


### PR DESCRIPTION
文档的第一个例子里，写了「把文件保存成 `xx.txt`」，不合适。

 - 命令行下，并不要求拓展名必须是 `tex`。
 - 但编辑器 TeXstudio 默认把主文件的拓展名变为 `tex`，保存成 `txt` 会导致编辑器报错。编辑器默认配置如下
``` bash
# 这里百分号 % 代表去掉拓展名的文件名
xelatex -synctex=1 -interaction=nonstopmode %.tex
```